### PR TITLE
prodeng-323 response handling refactor

### DIFF
--- a/examples/get_results.py
+++ b/examples/get_results.py
@@ -12,7 +12,7 @@ from datetime import date, timedelta
 from typing import Optional
 
 from realitydefender import RealityDefender, RealityDefenderError
-from realitydefender.types import DetectionResultList
+from realitydefender.model import DetectionResultList
 
 
 def format_score(score: Optional[float]) -> str:

--- a/examples/sync_usage.py
+++ b/examples/sync_usage.py
@@ -11,7 +11,7 @@ import time
 from typing import Optional
 
 from realitydefender import RealityDefender, RealityDefenderError
-from realitydefender.types import DetectionResult
+from realitydefender.model import DetectionResult
 
 
 def format_score(score: Optional[float]) -> str:

--- a/examples/video_detection.py
+++ b/examples/video_detection.py
@@ -11,7 +11,7 @@ import time
 from typing import Optional
 
 from realitydefender import RealityDefender, RealityDefenderError
-from realitydefender.types import DetectionResult
+from realitydefender.model import DetectionResult
 
 
 def format_score(score: Optional[float]) -> str:

--- a/src/realitydefender/__init__.py
+++ b/src/realitydefender/__init__.py
@@ -6,7 +6,7 @@ Client library for deepfake detection using the Reality Defender API
 from .detection.results import get_detection_result
 from .detection.upload import upload_file
 from .errors import ErrorCode, RealityDefenderError
-from .types import (
+from realitydefender.model import (
     DetectionResult,
     UploadResult,
 )

--- a/src/realitydefender/core/events.py
+++ b/src/realitydefender/core/events.py
@@ -4,7 +4,7 @@ Event handling for asynchronous operations
 
 from typing import Any, Callable, Dict, List, Optional, TypeVar, Union, overload
 
-from realitydefender.types import ErrorHandler, EventName, ResultHandler
+from realitydefender.model import ErrorHandler, EventName, ResultHandler
 
 # Create a generic type for event names that can be either the specific EventName type
 # or any string (for testing purposes)

--- a/src/realitydefender/detection/results.py
+++ b/src/realitydefender/detection/results.py
@@ -11,7 +11,7 @@ from realitydefender.core.constants import (
     DEFAULT_POLLING_INTERVAL,
 )
 from realitydefender.errors import RealityDefenderError
-from realitydefender.types import DetectionResult, ModelResult, DetectionResultList
+from realitydefender.model import DetectionResult, ModelResult, DetectionResultList
 from realitydefender.utils.async_utils import sleep
 
 # Generic type for the HTTP client

--- a/src/realitydefender/detection/upload.py
+++ b/src/realitydefender/detection/upload.py
@@ -8,7 +8,7 @@ from typing import Any, Dict
 from realitydefender.client.http_client import HttpClient
 from realitydefender.core.constants import API_PATHS
 from realitydefender.errors import RealityDefenderError
-from realitydefender.types import UploadResult
+from realitydefender.model import UploadResult
 from realitydefender.utils.file_utils import get_file_info
 
 

--- a/src/realitydefender/errors.py
+++ b/src/realitydefender/errors.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 # Error codes returned by the SDK
 ErrorCode = Literal[
-    "unauthorized",  # Invalid or missing API key
+    "unauthorized",  # Authorization related error
     "server_error",  # Server-side error occurred
     "timeout",  # Operation timed out
     "invalid_file",  # File not found or invalid format

--- a/src/realitydefender/model.py
+++ b/src/realitydefender/model.py
@@ -8,6 +8,19 @@ from typing import Dict, Literal, Protocol, Union, Any
 from realitydefender.errors import RealityDefenderError
 
 
+class BasicResponse(TypedDict):
+    """A basic response from Reality Defender API"""
+
+    code: str
+    """Short code describing the nature of the returned message"""
+
+    response: str
+    """Description of the response"""
+
+    errno: int | None
+    """Error code, if any"""
+
+
 class UploadResult(TypedDict):
     """Result of a successful upload"""
 
@@ -71,7 +84,7 @@ class ResultHandler(Protocol):
     """Event handler for detection results"""
 
     def __call__(
-            self, result: Any
+        self, result: Any
     ) -> None: ...  # Use Any instead of DetectionResult to avoid type errors
 
 

--- a/src/realitydefender/reality_defender.py
+++ b/src/realitydefender/reality_defender.py
@@ -16,7 +16,7 @@ from realitydefender.core.events import EventEmitter
 from realitydefender.detection.results import get_detection_result, get_detection_results
 from realitydefender.detection.upload import upload_file
 from realitydefender.errors import RealityDefenderError
-from realitydefender.types import (
+from realitydefender.model import (
     DetectionResult,
     ErrorHandler,
     ResultHandler,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -94,10 +94,8 @@ async def test_handle_response_400_free_tier_error(http_client: HttpClient) -> N
     mock_response.status = 400
     mock_response.json = AsyncMock(
         return_value={
-            "error": {
-                "code": "free-tier-not-allowed",
-                "message": "Error: paid plan required",
-            }
+            "code": "free-tier-not-allowed",
+            "response": "Error: paid plan required",
         }
     )
 
@@ -114,16 +112,14 @@ async def test_handle_response_400_other_error(http_client: HttpClient) -> None:
     mock_response = AsyncMock(spec=aiohttp.ClientResponse)
     mock_response.status = 400
     mock_response.json = AsyncMock(
-        return_value={
-            "error": {"code": "validation-error", "message": "Invalid file format"}
-        }
+        return_value={"code": "validation-error", "response": "Invalid file format"}
     )
 
     with pytest.raises(RealityDefenderError) as exc_info:
         await http_client._handle_response(mock_response)
 
     assert exc_info.value.code == "server_error"
-    assert "API error: Invalid file format" in str(exc_info.value)
+    assert "Bad request: Invalid file format" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
@@ -139,7 +135,7 @@ async def test_handle_response_400_missing_error_structure(
         await http_client._handle_response(mock_response)
 
     assert exc_info.value.code == "server_error"
-    assert "API error: Unknown error" in str(exc_info.value)
+    assert "Bad request: Unknown error" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
@@ -147,13 +143,13 @@ async def test_handle_response_400_empty_error_fields(http_client: HttpClient) -
     """Test 400 response with empty error code and message"""
     mock_response = AsyncMock(spec=aiohttp.ClientResponse)
     mock_response.status = 400
-    mock_response.json = AsyncMock(return_value={"error": {}})
+    mock_response.json = AsyncMock(return_value={})
 
     with pytest.raises(RealityDefenderError) as exc_info:
         await http_client._handle_response(mock_response)
 
     assert exc_info.value.code == "server_error"
-    assert "API error: Unknown error" in str(exc_info.value)
+    assert "Bad request: Unknown error" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
@@ -179,7 +175,7 @@ async def test_post_error(http_client: HttpClient, mock_response: AsyncMock) -> 
             await http_client.post("/test")
 
         assert exc_info.value.code == "server_error"
-        assert "Server error" in str(exc_info.value)
+        assert "API error: Unknown error" in str(exc_info.value)
 
 
 @pytest.mark.asyncio

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -13,7 +13,7 @@ from realitydefender.detection.upload import (
     upload_file,
 )
 from realitydefender.errors import RealityDefenderError
-from realitydefender.types import UploadResult
+from realitydefender.model import UploadResult
 
 
 @pytest.fixture


### PR DESCRIPTION
* It should now handle errors where the customer runs out of credits.
* This change will now serve as the baseline for all the other SDKs, so they all should return the same or similar error messages for the same conditions (hopefully).
* Renamed `types` for `model` because Mypy couldn't stop complaining about having a module with `type` in the name.