### PR TITLE
ruff format and fix error

### DIFF
--- a/examples/get_results.py
+++ b/examples/get_results.py
@@ -28,16 +28,18 @@ def print_results(results: DetectionResultList) -> None:
     print(f"Current Page: {results['current_page'] + 1} of {results['total_pages']}")
     print(f"Results on this page: {results['current_page_items_count']}")
 
-    if results['items']:
+    if results["items"]:
         print("\nDetection Results:")
-        for i, result in enumerate(results['items'], 1):
+        for i, result in enumerate(results["items"], 1):
             print(f"\n{i}. Status: {result['status']}")
             print(f"   Score: {format_score(result['score'])}")
 
-            if result['models']:
+            if result["models"]:
                 print("   Models:")
-                for model in result['models']:
-                    print(f"     - {model['name']}: {model['status']} (Score: {format_score(model['score'])})")
+                for model in result["models"]:
+                    print(
+                        f"     - {model['name']}: {model['status']} (Score: {format_score(model['score'])})"
+                    )
     else:
         print("\nNo results found.")
 
@@ -69,10 +71,7 @@ def sync_example() -> None:
 
         print(f"\n\nFetching results from {start_date} to {end_date}...")
         filtered_results = client.get_results_sync(
-            page_number=0,
-            size=10,
-            start_date=start_date,
-            end_date=end_date
+            page_number=0, size=10, start_date=start_date, end_date=end_date
         )
         print_results(filtered_results)
 
@@ -109,14 +108,12 @@ async def async_example() -> None:
         # Example with name filter
         print("\n\nFetching results filtered by name containing 'test'...")
         name_filtered_results = await client.get_results(
-            page_number=0,
-            size=10,
-            name="test"
+            page_number=0, size=10, name="test"
         )
         print_results(name_filtered_results)
 
         # Example showing pagination
-        if results['total_pages'] > 1:
+        if results["total_pages"] > 1:
             print("\n\nFetching page 2 of results...")
             page2_results = await client.get_results(page_number=1, size=5)
             print_results(page2_results)

--- a/src/realitydefender/client/http_client.py
+++ b/src/realitydefender/client/http_client.py
@@ -33,7 +33,7 @@ class HttpClient:
             config: Configuration including API key and base URL
         """
         self.api_key = config["api_key"]
-        self.base_url = config.get("base_url", DEFAULT_API_ENDPOINT)
+        self.base_url = config.get("base_url") or DEFAULT_API_ENDPOINT
         self.session: Optional[aiohttp.ClientSession] = None
 
     async def ensure_session(self) -> aiohttp.ClientSession:
@@ -156,12 +156,12 @@ class HttpClient:
             if code in ["free-tier-not-allowed", "upload-limit-reached"]:
                 raise RealityDefenderError(response, "unauthorized")
             else:
-                raise RealityDefenderError(f"Invalid request: {response}", "invalid_request")
+                raise RealityDefenderError(
+                    f"Invalid request: {response}", "invalid_request"
+                )
 
         elif client_response.status == 401:
-            raise RealityDefenderError(
-                "Invalid API key", "unauthorized"
-            )
+            raise RealityDefenderError("Invalid API key", "unauthorized")
 
         elif client_response.status == 404:
             raise RealityDefenderError("Resource not found", "not_found")

--- a/src/realitydefender/core/constants.py
+++ b/src/realitydefender/core/constants.py
@@ -9,7 +9,7 @@ DEFAULT_API_ENDPOINT = "https://api.prd.realitydefender.xyz"
 API_PATHS = {
     "SIGNED_URL": "/api/files/aws-presigned",
     "MEDIA_RESULT": "/api/media/users",
-    "ALL_MEDIA_RESULTS": "/api/v2/media/users/pages"
+    "ALL_MEDIA_RESULTS": "/api/v2/media/users/pages",
 }
 
 # Default polling interval in milliseconds
@@ -25,6 +25,9 @@ DEFAULT_MAX_ATTEMPTS = 30
 SUPPORTED_FILE_TYPES: list[dict] = [
     {"extensions": [".mp4", ".mov"], "size_limit": 262144000},
     {"extensions": [".jpg", ".png", ".jpeg", ".gif", ".webp"], "size_limit": 52428800},
-    {"extensions": [".flac", ".wav", ".mp3", ".m4a", ".aac", ".alac", ".ogg"], "size_limit": 20971520},
-    {"extensions": [".txt"], "size_limit": 5242880}
+    {
+        "extensions": [".flac", ".wav", ".mp3", ".m4a", ".aac", ".alac", ".ogg"],
+        "size_limit": 20971520,
+    },
+    {"extensions": [".txt"], "size_limit": 5242880},
 ]

--- a/src/realitydefender/detection/results.py
+++ b/src/realitydefender/detection/results.py
@@ -1,6 +1,7 @@
 """
 Detection results retrieval and processing
 """
+
 from datetime import date
 from typing import Any, Dict, TypeVar, Optional
 
@@ -41,12 +42,14 @@ async def get_media_result(client: ClientType, request_id: str) -> Dict[str, Any
         raise RealityDefenderError(f"Failed to get result: {str(e)}", "unknown_error")
 
 
-async def get_media_results(client: ClientType,
-                            page_number: int = 0,
-                            size: int = 10,
-                            name: Optional[str] = None,
-                            start_date: Optional[date] = None,
-                            end_date: Optional[date] = None) -> Dict[str, Any]:
+async def get_media_results(
+    client: ClientType,
+    page_number: int = 0,
+    size: int = 10,
+    name: Optional[str] = None,
+    start_date: Optional[date] = None,
+    end_date: Optional[date] = None,
+) -> Dict[str, Any]:
     """
     Fetches media results from the specified client with optional filters such as page number, size, name,
     start date, and end date. This is an asynchronous function and communicates with an external API
@@ -81,9 +84,9 @@ async def get_media_results(client: ClientType,
         if name:
             params["name"] = str(name)
         if start_date:
-            params["startDate"] = start_date.strftime('%Y-%m-%d')
+            params["startDate"] = start_date.strftime("%Y-%m-%d")
         if end_date:
-            params["endDate"] = end_date.strftime('%Y-%m-%d')
+            params["endDate"] = end_date.strftime("%Y-%m-%d")
 
         return await client.get(path=path, params=params)
     except RealityDefenderError:
@@ -150,7 +153,12 @@ def format_result(response: Dict[str, Any]) -> DetectionResult:
                 }
             )
 
-        return {"request_id": request_id, "status": status, "score": score, "models": models}
+        return {
+            "request_id": request_id,
+            "status": status,
+            "score": score,
+            "models": models,
+        }
 
     # Return a default empty result if we couldn't parse the response
     return {"request_id": request_id, "status": "UNKNOWN", "score": None, "models": []}
@@ -170,15 +178,27 @@ def format_result_list(response: Dict[str, Any]) -> DetectionResultList:
         Reraises any exceptions encountered during formatting.
     """
     # Handle regular API responses
-    if response is None or any([response.get(x) is None for x in
-                                ["totalItems", "totalPages", "currentPage", "currentPageItemsCount", "mediaList"]]):
+    if response is None or any(
+        [
+            response.get(x) is None
+            for x in [
+                "totalItems",
+                "totalPages",
+                "currentPage",
+                "currentPageItemsCount",
+                "mediaList",
+            ]
+        ]
+    ):
         raise RealityDefenderError("Invalid response from server", "server_error")
 
-    result = DetectionResultList(total_items=response.get("totalItems", 0),
-                                 total_pages=response.get("totalPages", 0),
-                                 current_page=response.get("currentPage", 0),
-                                 current_page_items_count=response.get("currentPageItemsCount", 0),
-                                 items=[])
+    result = DetectionResultList(
+        total_items=response.get("totalItems", 0),
+        total_pages=response.get("totalPages", 0),
+        current_page=response.get("currentPage", 0),
+        current_page_items_count=response.get("currentPageItemsCount", 0),
+        items=[],
+    )
 
     for item in response.get("mediaList", []):
         result.setdefault("items", []).append(format_result(item))
@@ -187,10 +207,10 @@ def format_result_list(response: Dict[str, Any]) -> DetectionResultList:
 
 
 async def get_detection_result(
-        client: ClientType,
-        request_id: str,
-        max_attempts: int = DEFAULT_MAX_ATTEMPTS,
-        polling_interval: int = DEFAULT_POLLING_INTERVAL,
+    client: ClientType,
+    request_id: str,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+    polling_interval: int = DEFAULT_POLLING_INTERVAL,
 ) -> DetectionResult:
     """
     Get the detection result for a specific request
@@ -252,15 +272,16 @@ async def get_detection_result(
     return format_result(media_result)
 
 
-async def get_detection_results(client: ClientType,
-                                page_number: int = 0,
-                                size: int = 10,
-                                name: Optional[str] = None,
-                                start_date: Optional[date] = None,
-                                end_date: Optional[date] = None,
-                                max_attempts: int = DEFAULT_MAX_ATTEMPTS,
-                                polling_interval: int = DEFAULT_POLLING_INTERVAL,
-                                ) -> DetectionResultList:
+async def get_detection_results(
+    client: ClientType,
+    page_number: int = 0,
+    size: int = 10,
+    name: Optional[str] = None,
+    start_date: Optional[date] = None,
+    end_date: Optional[date] = None,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+    polling_interval: int = DEFAULT_POLLING_INTERVAL,
+) -> DetectionResultList:
     """
     Retrieves detection results asynchronously based on specified criteria. This function
     communicates with the client to fetch paginated detection results. Optionally, filters
@@ -301,7 +322,9 @@ async def get_detection_results(client: ClientType,
     while attempts < max_attempts:
         try:
             # Get the current media result
-            media_results = await get_media_results(client, page_number, size, name, start_date, end_date)
+            media_results = await get_media_results(
+                client, page_number, size, name, start_date, end_date
+            )
 
             # Format and return the result
             return format_result_list(media_results)

--- a/src/realitydefender/reality_defender.py
+++ b/src/realitydefender/reality_defender.py
@@ -11,16 +11,24 @@ from typing import Any, Callable, Coroutine, Optional, TypeVar, cast
 import asyncio_atexit  # type:ignore
 
 from realitydefender.client import create_http_client
-from realitydefender.core.constants import DEFAULT_POLLING_INTERVAL, DEFAULT_TIMEOUT, DEFAULT_MAX_ATTEMPTS
+from realitydefender.core.constants import (
+    DEFAULT_POLLING_INTERVAL,
+    DEFAULT_TIMEOUT,
+    DEFAULT_MAX_ATTEMPTS,
+)
 from realitydefender.core.events import EventEmitter
-from realitydefender.detection.results import get_detection_result, get_detection_results
+from realitydefender.detection.results import (
+    get_detection_result,
+    get_detection_results,
+)
 from realitydefender.detection.upload import upload_file
 from realitydefender.errors import RealityDefenderError
 from realitydefender.model import (
     DetectionResult,
     ErrorHandler,
     ResultHandler,
-    UploadResult, DetectionResultList,
+    UploadResult,
+    DetectionResultList,
 )
 
 T = TypeVar("T")
@@ -100,10 +108,10 @@ class RealityDefender(EventEmitter):
         return self._run_async(self.upload(file_path))
 
     async def get_result(
-            self,
-            request_id: str,
-            max_attempts: int = DEFAULT_MAX_ATTEMPTS,
-            polling_interval: int = DEFAULT_POLLING_INTERVAL,
+        self,
+        request_id: str,
+        max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+        polling_interval: int = DEFAULT_POLLING_INTERVAL,
     ) -> DetectionResult:
         """
         Get the detection result for a specific request ID (async version)
@@ -124,14 +132,14 @@ class RealityDefender(EventEmitter):
         )
 
     async def get_results(
-            self,
-            page_number: int = 0,
-            size: int = 10,
-            name: Optional[str] = None,
-            start_date: Optional[date] = None,
-            end_date: Optional[date] = None,
-            max_attempts: int = DEFAULT_MAX_ATTEMPTS,
-            polling_interval: int = DEFAULT_POLLING_INTERVAL,
+        self,
+        page_number: int = 0,
+        size: int = 10,
+        name: Optional[str] = None,
+        start_date: Optional[date] = None,
+        end_date: Optional[date] = None,
+        max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+        polling_interval: int = DEFAULT_POLLING_INTERVAL,
     ) -> DetectionResultList:
         """
         Fetches the results of detections from the client asynchronously with pagination, date
@@ -167,10 +175,10 @@ class RealityDefender(EventEmitter):
         )
 
     def get_result_sync(
-            self,
-            request_id: str,
-            max_attempts: int = DEFAULT_MAX_ATTEMPTS,
-            polling_interval: int = DEFAULT_POLLING_INTERVAL,
+        self,
+        request_id: str,
+        max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+        polling_interval: int = DEFAULT_POLLING_INTERVAL,
     ) -> DetectionResult:
         """
         Get the detection result for a specific request ID (synchronous version)
@@ -192,14 +200,14 @@ class RealityDefender(EventEmitter):
         )
 
     def get_results_sync(
-            self,
-            page_number: int = 0,
-            size: int = 10,
-            name: Optional[str] = None,
-            start_date: Optional[date] = None,
-            end_date: Optional[date] = None,
-            max_attempts: int = DEFAULT_MAX_ATTEMPTS,
-            polling_interval: int = DEFAULT_POLLING_INTERVAL,
+        self,
+        page_number: int = 0,
+        size: int = 10,
+        name: Optional[str] = None,
+        start_date: Optional[date] = None,
+        end_date: Optional[date] = None,
+        max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+        polling_interval: int = DEFAULT_POLLING_INTERVAL,
     ) -> DetectionResultList:
         """
         Fetches a list of detection results synchronously with optional parameters for filtering and pagination.
@@ -260,10 +268,10 @@ class RealityDefender(EventEmitter):
         return self.get_result_sync(request_id)
 
     async def poll_for_results(
-            self,
-            request_id: str,
-            polling_interval: Optional[int] = None,
-            timeout: Optional[int] = None,
+        self,
+        request_id: str,
+        polling_interval: Optional[int] = None,
+        timeout: Optional[int] = None,
     ) -> None:
         """
         Start polling for results with event-based callback (async version)
@@ -320,13 +328,13 @@ class RealityDefender(EventEmitter):
             )
 
     def poll_for_results_sync(
-            self,
-            request_id: str,
-            *,  # Force keyword arguments for better readability
-            polling_interval: Optional[int] = None,
-            timeout: Optional[int] = None,
-            on_result: Optional[Callable[[DetectionResult], None]] = None,
-            on_error: Optional[Callable[[RealityDefenderError], None]] = None,
+        self,
+        request_id: str,
+        *,  # Force keyword arguments for better readability
+        polling_interval: Optional[int] = None,
+        timeout: Optional[int] = None,
+        on_result: Optional[Callable[[DetectionResult], None]] = None,
+        on_error: Optional[Callable[[RealityDefenderError], None]] = None,
     ) -> None:
         """
         Start polling for results with synchronous callbacks

--- a/src/realitydefender/utils/file_utils.py
+++ b/src/realitydefender/utils/file_utils.py
@@ -32,12 +32,22 @@ def get_file_info(file_path: str) -> Tuple[str, bytes, str]:
         file_size = os.path.getsize(file_path)
         file_extension: str = os.path.splitext(filename)[1].lower()
         file_extension_size_limit: int = next(
-            (x.get("size_limit", 0) for x in SUPPORTED_FILE_TYPES if file_extension in x.get("extensions", [])), 0)
+            (
+                x.get("size_limit", 0)
+                for x in SUPPORTED_FILE_TYPES
+                if file_extension in x.get("extensions", [])
+            ),
+            0,
+        )
 
         if file_extension_size_limit == 0:
-            raise RealityDefenderError(f"Unsupported file type: {file_extension}", "invalid_file")
+            raise RealityDefenderError(
+                f"Unsupported file type: {file_extension}", "invalid_file"
+            )
         if file_size > file_extension_size_limit:
-            raise RealityDefenderError(f"File too large to upload: {file_path}", "file_too_large")
+            raise RealityDefenderError(
+                f"File too large to upload: {file_path}", "file_too_large"
+            )
 
         # Determine content type
         content_type, _ = mimetypes.guess_type(file_path)

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -9,24 +9,24 @@ from realitydefender.errors import RealityDefenderError
 
 def test_get_file_info_success() -> None:
     """Test successful file info extraction"""
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
-        f.write('Hello, world!')
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write("Hello, world!")
         temp_path = f.name
 
     try:
         filename, content, mime_type = get_file_info(temp_path)
 
         assert filename == os.path.basename(temp_path)
-        assert content == b'Hello, world!'
-        assert mime_type == 'text/plain'
+        assert content == b"Hello, world!"
+        assert mime_type == "text/plain"
     finally:
         os.unlink(temp_path)
 
 
 def test_get_file_info_binary_content() -> None:
     """Test file with binary content"""
-    with tempfile.NamedTemporaryFile(suffix='.jpg', delete=False) as f:
-        binary_data = b'\x89PNG\r\n\x1a\n'
+    with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as f:
+        binary_data = b"\x89PNG\r\n\x1a\n"
         f.write(binary_data)
         temp_path = f.name
 
@@ -35,15 +35,15 @@ def test_get_file_info_binary_content() -> None:
 
         assert filename == os.path.basename(temp_path)
         assert content == binary_data
-        assert mime_type == 'image/jpeg'
+        assert mime_type == "image/jpeg"
     finally:
         os.unlink(temp_path)
 
 
 def test_get_file_info_unknown_mime_type() -> None:
     """Test file with unknown extension defaults to octet-stream"""
-    with tempfile.NamedTemporaryFile(suffix='.unknown', delete=False) as f:
-        f.write(b'test')
+    with tempfile.NamedTemporaryFile(suffix=".unknown", delete=False) as f:
+        f.write(b"test")
         temp_path = f.name
 
     with pytest.raises(RealityDefenderError) as exc_info:
@@ -51,31 +51,31 @@ def test_get_file_info_unknown_mime_type() -> None:
             _, _, mime_type = get_file_info(temp_path)
         finally:
             os.unlink(temp_path)
-        assert exc_info.value.code == 'invalid_file'
+        assert exc_info.value.code == "invalid_file"
 
 
 def test_get_file_info_file_not_found() -> None:
     """Test error when file doesn't exist"""
     with pytest.raises(RealityDefenderError) as exc_info:
-        get_file_info('/nonexistent/file.txt')
+        get_file_info("/nonexistent/file.txt")
 
-    assert exc_info.value.code == 'invalid_file'
-    assert 'File not found' in str(exc_info.value)
+    assert exc_info.value.code == "invalid_file"
+    assert "File not found" in str(exc_info.value)
 
 
 def test_get_file_info_file_too_large() -> None:
     """Test error when file exceeds size limit"""
-    with tempfile.NamedTemporaryFile(suffix='.txt', delete=False) as f:
+    with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
         # Write content larger than txt limit (5MB)
-        f.write(b'x' * (5242880 + 1))
+        f.write(b"x" * (5242880 + 1))
         temp_path = f.name
 
     try:
         with pytest.raises(RealityDefenderError) as exc_info:
             get_file_info(temp_path)
 
-        assert exc_info.value.code == 'file_too_large'
-        assert 'File too large' in str(exc_info.value)
+        assert exc_info.value.code == "file_too_large"
+        assert "File too large" in str(exc_info.value)
     finally:
         os.unlink(temp_path)
 
@@ -83,22 +83,22 @@ def test_get_file_info_file_too_large() -> None:
 def test_get_file_info_supported_extensions() -> None:
     """Test various supported file extensions return correct info"""
     test_cases = [
-        ('.mp4', 'video/mp4'),
-        ('.jpg', 'image/jpeg'),
-        ('.png', 'image/png'),
-        ('.mp3', 'audio/mpeg'),
-        ('.txt', 'text/plain')
+        (".mp4", "video/mp4"),
+        (".jpg", "image/jpeg"),
+        (".png", "image/png"),
+        (".mp3", "audio/mpeg"),
+        (".txt", "text/plain"),
     ]
 
     for ext, expected_mime in test_cases:
         with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as f:
-            f.write(b'test')
+            f.write(b"test")
             temp_path = f.name
 
         try:
             filename, content, mime_type = get_file_info(temp_path)
             assert filename.endswith(ext)
-            assert content == b'test'
+            assert content == b"test"
             assert mime_type == expected_mime
         finally:
             os.unlink(temp_path)


### PR DESCRIPTION
diff is messy because I ran `ruff format` we should just make sure that our IDEs are set up to run that on save, and I guess at some point set it up in CI/CD

The actual fix is this
```
        self.base_url = config.get("base_url") or DEFAULT_API_ENDPOINT
```

The problem is that "base_url" DOES get set, but if no value is passed to `RealityDefender()` then that value is None, so `.get()` will return `None`

I also modified a test to check this